### PR TITLE
Fix: missing `find_if` namespace

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -227,7 +227,7 @@ void BaseRealSenseNode::setupErrorCallback()
             {
                 ROS_WARN_STREAM("Hardware Notification:" << n.get_description() << "," << n.get_timestamp() << "," << n.get_severity() << "," << n.get_category());
             }
-            if (error_strings.end() != find_if(error_strings.begin(), error_strings.end(), [&n] (std::string err) 
+            if (error_strings.end() != std::find_if(error_strings.begin(), error_strings.end(), [&n] (std::string err)
                                         {return (n.get_description().find(err) != std::string::npos); }))
             {
                 ROS_ERROR_STREAM("Performing Hardware Reset.");


### PR DESCRIPTION
## Description

This is a fix for an issue I ran into while trying to build the package `development-gazebo` branch. A `find_if` call in `base_realsense_node.cpp` was missing its namespace (i.e. `std`), which leads to the build error:
```
_____________________________________________________________________________________________________________________________
Errors     << realsense2_camera:make .../logs/realsense2_camera/build.make.002.log                             
.../src/realsense_gazebo/realsense-ros/realsense2_camera/src/base_realsense_node.cpp: In member function ‘void realsense2_camera::BaseRealSenseNode::publishPointCloud(rs2::points, const ros::Time&, const rs2::frameset&)’:
.../src/realsense_gazebo/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:2167:29: error: ‘find_if’ was not declared in this scope
 2167 |         texture_frame_itr = find_if(frameset.begin(), frameset.end(), [&texture_source_id, &available_formats] (rs2::frame f)
      |                             ^~~~~~~
.../src/realsense_gazebo/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:2167:29: note: suggested alternatives:
In file included from /usr/include/c++/9/algorithm:62,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:39,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /opt/ros/noetic/include/class_loader/class_loader.hpp:36,
                 from /opt/ros/noetic/include/pluginlib/./class_list_macros.hpp:40,
                 from /opt/ros/noetic/include/pluginlib/class_list_macros.h:35,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/../include/../include/realsense_node_factory.h:6,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/../include/base_realsense_node.h:6,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:1:
/usr/include/c++/9/bits/stl_algo.h:3960:5: note:   ‘std::find_if’
 3960 |     find_if(_InputIterator __first, _InputIterator __last,
      |     ^~~~~~~
In file included from /usr/include/boost/mpl/find.hpp:17,
                 from /usr/include/boost/mpl/aux_/contains_impl.hpp:20,
                 from /usr/include/boost/mpl/contains.hpp:20,
                 from /usr/include/boost/math/policies/policy.hpp:10,
                 from /usr/include/boost/math/policies/error_handling.hpp:21,
                 from /usr/include/boost/math/special_functions/round.hpp:14,
                 from /opt/ros/noetic/include/ros/time.h:58,
                 from /opt/ros/noetic/include/ros/console.h:39,
                 from /opt/ros/noetic/include/nodelet/nodelet.h:40,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/../include/../include/realsense_node_factory.h:7,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/../include/base_realsense_node.h:6,
                 from .../src/realsense_gazebo/realsense-ros/realsense2_camera/src/base_realsense_node.cpp:1:
/usr/include/boost/mpl/find_if.hpp:32:8: note:   ‘boost::mpl::find_if’
   32 | struct find_if
      |        ^~~~~~~
make[2]: *** [CMakeFiles/realsense2_camera.dir/build.make:90: CMakeFiles/realsense2_camera.dir/src/base_realsense_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2795: CMakeFiles/realsense2_camera.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
cd .../build/realsense2_camera; catkin build --get-env realsense2_camera | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -

.................................................................................................................................
Failed     << realsense2_camera:make                               [ Exited with code 2 ]                                        
Failed    <<< realsense2_camera                                    [ 13.8 seconds ]       
```

This may need to be fixed in other branches as well.

P.S.: Thanks for the camera URDF files; I found them useful in my work.